### PR TITLE
9 あとから置いたカードが上になるように

### DIFF
--- a/index.html
+++ b/index.html
@@ -98,7 +98,6 @@ var promises =[];
 //                $("#"+ id).prependTo("#movedcard");
 //                $("#"+ id).css("position", "absolute");
                 $("#" + id).offset(offset);
-                console.log(id);
 
             });
             $("#" + element.id).mousedown(evnent => {


### PR DESCRIPTION
ついでに計算がおかしくなる問題も修正できた。

上にカードがあると、そのカードのmouseupイベントが発火してしまうため、動かしたカードの点数計算が動かなかったため。